### PR TITLE
fix: use ERC20Permit and update constructor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	branch = merge/release-v4.9
+	branch = 4.9.3
 [submodule "lib/permit2"]
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,10 @@
 	path = lib/isolmate
 	url = https://github.com/defi-wonderland/isolmate
 	branch = main
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+	branch = merge/release-v4.9
 [submodule "lib/permit2"]
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,11 +14,6 @@
 	path = lib/isolmate
 	url = https://github.com/defi-wonderland/isolmate
 	branch = main
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-[submodule "lib\\openzeppelin-contracts"]
-	branch = v4.8.3
 [submodule "lib/permit2"]
 	path = lib/permit2
 	url = https://github.com/Uniswap/permit2

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,7 @@ multiline_func_header = 'params_first'
 fs_permissions = [{ access = "read-write", path = "./"}]
 
 [profile.default]
-solc = '0.8.14'
+solc = '0.8.23'
 src = 'solidity'
 test = 'solidity/test'
 out = 'out'

--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -39,8 +39,8 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
     string memory _name,
     string memory _symbol,
     address _factory
-  ) ERC20(_name, _symbol) ERC20Permit(_name) Ownable(_factory) {
-
+  ) ERC20(_name, _symbol) ERC20Permit(_name) {
+    _transferOwnership(_factory);
     FACTORY = _factory;
   }
 

--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.4 <0.9.0;
 
 import {IXERC20} from '../interfaces/IXERC20.sol';
 import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
-import {ERC20Permit} from '@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol';
+import {ERC20Permit} from '@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol';
 import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 
 contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
@@ -39,8 +39,8 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
     string memory _name,
     string memory _symbol,
     address _factory
-  ) ERC20(string.concat('x', _name), string.concat('x', _symbol)) ERC20Permit(string.concat('x', _name)) {
-    _transferOwnership(_factory);
+  ) ERC20(string.concat('x', _name), string.concat('x', _symbol)) ERC20Permit(string.concat('x', _name)) Ownable(_factory) {
+
     FACTORY = _factory;
   }
 

--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -39,7 +39,7 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
     string memory _name,
     string memory _symbol,
     address _factory
-  ) ERC20(string.concat('x', _name), string.concat('x', _symbol)) ERC20Permit(string.concat('x', _name)) Ownable(_factory) {
+  ) ERC20(_name, _symbol) ERC20Permit(_name) Ownable(_factory) {
 
     FACTORY = _factory;
   }

--- a/solidity/test/e2e/XERC20Factory.t.sol
+++ b/solidity/test/e2e/XERC20Factory.t.sol
@@ -7,8 +7,8 @@ import {XERC20Lockbox} from '../../contracts/XERC20Lockbox.sol';
 contract E2EDeployment is CommonE2EBase {
   function testDeploy() public {
     assertEq(address(_xerc20.owner()), _owner);
-    assertEq(_xerc20.name(), 'xDai Stablecoin');
-    assertEq(_xerc20.symbol(), 'xDAI');
+    assertEq(_xerc20.name(), 'Dai Stablecoin');
+    assertEq(_xerc20.symbol(), 'DAI');
     assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
     assertEq(address(_lockbox.XERC20()), address(_xerc20));
     assertEq(address(_lockbox.ERC20()), address(_dai));

--- a/solidity/test/unit/XERC20.t.sol
+++ b/solidity/test/unit/XERC20.t.sol
@@ -25,11 +25,11 @@ abstract contract Base is Test {
 
 contract UnitNames is Base {
   function testName() public {
-    assertEq('xTest', _xerc20.name());
+    assertEq('Test', _xerc20.name());
   }
 
   function testSymbol() public {
-    assertEq('xTST', _xerc20.symbol());
+    assertEq('TST', _xerc20.symbol());
   }
 }
 

--- a/solidity/test/unit/XERC20Factory.t.sol
+++ b/solidity/test/unit/XERC20Factory.t.sol
@@ -35,7 +35,7 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
-    assertEq(XERC20(_xerc20).name(), 'xTest');
+    assertEq(XERC20(_xerc20).name(), 'Test');
   }
 
   function testRevertsWhenAddressIsTaken() public {


### PR DESCRIPTION
Since @openzeppelin/contracts v4.9 is only redirecting to the now final ERC20Permit implementatation.

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v4.9/contracts/token/ERC20/extensions/draft-ERC20Permit.sol

Since @openzeppelin contracts v5.0 `draft-ERC20Permit.sol` has been removed.