### PR TITLE
test: Limit limits

### DIFF
--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -34,7 +34,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _symbol The symbol of the token
    * @param _factory The factory which deployed this contract
    */
-
   constructor(string memory _name, string memory _symbol, address _factory) ERC20(_name, _symbol) ERC20Permit(_name) {
     _transferOwnership(_factory);
     FACTORY = _factory;
@@ -46,7 +45,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _user The address of the user who needs tokens minted
    * @param _amount The amount of tokens being minted
    */
-
   function mint(address _user, uint256 _amount) public {
     _mintWithCaller(msg.sender, _user, _amount);
   }
@@ -57,7 +55,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _user The address of the user who needs tokens burned
    * @param _amount The amount of tokens being burned
    */
-
   function burn(address _user, uint256 _amount) public {
     if (msg.sender != _user) {
       _spendAllowance(_user, msg.sender, _amount);
@@ -71,7 +68,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    *
    * @param _lockbox The address of the lockbox
    */
-
   function setLockbox(address _lockbox) public {
     if (msg.sender != FACTORY) revert IXERC20_NotFactory();
     lockbox = _lockbox;
@@ -87,6 +83,10 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge The address of the bridge we are setting the limits too
    */
   function setLimits(address _bridge, uint256 _mintingLimit, uint256 _burningLimit) external onlyOwner {
+    if (_mintingLimit > (type(uint256).max / 2) || _burningLimit > (type(uint256).max / 2)) {
+      revert IXERC20_LimitsTooHigh();
+    }
+
     _changeMinterLimit(_bridge, _mintingLimit);
     _changeBurnerLimit(_bridge, _burningLimit);
     emit BridgeLimitsSet(_mintingLimit, _burningLimit, _bridge);
@@ -98,7 +98,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-
   function mintingMaxLimitOf(address _bridge) public view returns (uint256 _limit) {
     _limit = bridges[_bridge].minterParams.maxLimit;
   }
@@ -109,7 +108,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-
   function burningMaxLimitOf(address _bridge) public view returns (uint256 _limit) {
     _limit = bridges[_bridge].burnerParams.maxLimit;
   }
@@ -120,7 +118,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-
   function mintingCurrentLimitOf(address _bridge) public view returns (uint256 _limit) {
     _limit = _getCurrentLimit(
       bridges[_bridge].minterParams.currentLimit,
@@ -136,7 +133,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-
   function burningCurrentLimitOf(address _bridge) public view returns (uint256 _limit) {
     _limit = _getCurrentLimit(
       bridges[_bridge].burnerParams.currentLimit,
@@ -151,7 +147,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge The address of the bridge who is being changed
    * @param _change The change in the limit
    */
-
   function _useMinterLimits(address _bridge, uint256 _change) internal {
     uint256 _currentLimit = mintingCurrentLimitOf(_bridge);
     bridges[_bridge].minterParams.timestamp = block.timestamp;
@@ -163,7 +158,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge The address of the bridge who is being changed
    * @param _change The change in the limit
    */
-
   function _useBurnerLimits(address _bridge, uint256 _change) internal {
     uint256 _currentLimit = burningCurrentLimitOf(_bridge);
     bridges[_bridge].burnerParams.timestamp = block.timestamp;
@@ -176,7 +170,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge The address of the bridge we are setting the limit too
    * @param _limit The updated limit we are setting to the bridge
    */
-
   function _changeMinterLimit(address _bridge, uint256 _limit) internal {
     uint256 _oldLimit = bridges[_bridge].minterParams.maxLimit;
     uint256 _currentLimit = mintingCurrentLimitOf(_bridge);
@@ -194,7 +187,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge The address of the bridge we are setting the limit too
    * @param _limit The updated limit we are setting to the bridge
    */
-
   function _changeBurnerLimit(address _bridge, uint256 _limit) internal {
     uint256 _oldLimit = bridges[_bridge].burnerParams.maxLimit;
     uint256 _currentLimit = burningCurrentLimitOf(_bridge);
@@ -214,7 +206,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _currentLimit The current limit
    * @return _newCurrentLimit The new current limit
    */
-
   function _calculateNewCurrentLimit(
     uint256 _limit,
     uint256 _oldLimit,
@@ -240,7 +231,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _ratePerSecond The rate per second
    * @return _limit The current limit
    */
-
   function _getCurrentLimit(
     uint256 _currentLimit,
     uint256 _maxLimit,
@@ -266,7 +256,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _user The user address
    * @param _amount The amount to burn
    */
-
   function _burnWithCaller(address _caller, address _user, uint256 _amount) internal {
     if (_caller != lockbox) {
       uint256 _currentLimit = burningCurrentLimitOf(_caller);
@@ -283,7 +272,6 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _user The user address
    * @param _amount The amount to mint
    */
-
   function _mintWithCaller(address _caller, address _user, uint256 _amount) internal {
     if (_caller != lockbox) {
       uint256 _currentLimit = mintingCurrentLimitOf(_caller);

--- a/solidity/interfaces/IXERC20.sol
+++ b/solidity/interfaces/IXERC20.sol
@@ -7,7 +7,6 @@ interface IXERC20 {
    *
    * @param _lockbox The address of the lockbox
    */
-
   event LockboxSet(address _lockbox);
 
   /**
@@ -22,14 +21,17 @@ interface IXERC20 {
   /**
    * @notice Reverts when a user with too low of a limit tries to call mint/burn
    */
-
   error IXERC20_NotHighEnoughLimits();
 
   /**
    * @notice Reverts when caller is not the factory
    */
-
   error IXERC20_NotFactory();
+
+  /**
+   * @notice Reverts when limits are too high
+   */
+  error IXERC20_LimitsTooHigh();
 
   /**
    * @notice Contains the full minting and burning data for a particular bridge
@@ -62,7 +64,6 @@ interface IXERC20 {
    *
    * @param _lockbox The address of the lockbox
    */
-
   function setLockbox(address _lockbox) external;
 
   /**
@@ -88,7 +89,6 @@ interface IXERC20 {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-
   function burningMaxLimitOf(address _bridge) external view returns (uint256 _limit);
 
   /**
@@ -97,7 +97,6 @@ interface IXERC20 {
    * @param _minter The minter we are viewing the limits of
    * @return _limit The limit the minter has
    */
-
   function mintingCurrentLimitOf(address _minter) external view returns (uint256 _limit);
 
   /**
@@ -106,7 +105,6 @@ interface IXERC20 {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-
   function burningCurrentLimitOf(address _bridge) external view returns (uint256 _limit);
 
   /**
@@ -115,7 +113,6 @@ interface IXERC20 {
    * @param _user The address of the user who needs tokens minted
    * @param _amount The amount of tokens being minted
    */
-
   function mint(address _user, uint256 _amount) external;
 
   /**
@@ -124,6 +121,5 @@ interface IXERC20 {
    * @param _user The address of the user who needs tokens burned
    * @param _amount The amount of tokens being burned
    */
-
   function burn(address _user, uint256 _amount) external;
 }

--- a/solidity/test/unit/XERC20.t.sol
+++ b/solidity/test/unit/XERC20.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.4 <0.9.0;
 
-import {Test, stdError} from 'forge-std/Test.sol';
+import {Test} from 'forge-std/Test.sol';
 import {XERC20} from '../../contracts/XERC20.sol';
 import {IXERC20} from '../../interfaces/IXERC20.sol';
 
@@ -55,25 +55,16 @@ contract UnitMintBurn is Base {
     vm.stopPrank();
   }
 
-  function testMintRevertsWhenLimitIsTooHighAfterFirstMint(
-    uint256 _amount0,
-    uint256 _timePassed,
-    uint256 _limit
-  ) public {
+  function testsetLimitsRevertsWhenLimitIsTooHighAfter(uint256 _amount0, uint256 _timePassed, uint256 _limit) public {
     _amount0 = bound(_amount0, 1, 1e40);
     _limit = bound(_limit, UINT256_MAX / 2 + 1, UINT256_MAX);
     _timePassed = bound(_timePassed, 1, 1 days - 1);
 
     vm.assume(_limit > _amount0);
     vm.prank(_owner);
+    vm.expectRevert(IXERC20.IXERC20_LimitsTooHigh.selector);
     _xerc20.setLimits(_user, _limit, _limit);
 
-    vm.startPrank(_user);
-    _xerc20.mint(_user, _amount0);
-
-    skip(_timePassed);
-    //vm.expectRevert(stdError.arithmeticError);
-    _xerc20.mint(_user, _amount0);
     vm.stopPrank();
   }
 

--- a/solidity/test/unit/XERC20.t.sol
+++ b/solidity/test/unit/XERC20.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.4 <0.9.0;
 
-import {Test} from 'forge-std/Test.sol';
+import {Test, stdError} from 'forge-std/Test.sol';
 import {XERC20} from '../../contracts/XERC20.sol';
 import {IXERC20} from '../../interfaces/IXERC20.sol';
 
@@ -52,6 +52,28 @@ contract UnitMintBurn is Base {
     _xerc20.mint(_user, _amount0);
     vm.expectRevert(IXERC20.IXERC20_NotHighEnoughLimits.selector);
     _xerc20.burn(_user, _amount1);
+    vm.stopPrank();
+  }
+
+  function testMintRevertsWhenLimitIsTooHighAfterFirstMint(
+    uint256 _amount0,
+    uint256 _timePassed,
+    uint256 _limit
+  ) public {
+    _amount0 = bound(_amount0, 1, 1e40);
+    _limit = bound(_limit, UINT256_MAX / 2 + 1, UINT256_MAX);
+    _timePassed = bound(_timePassed, 1, 1 days - 1);
+
+    vm.assume(_limit > _amount0);
+    vm.prank(_owner);
+    _xerc20.setLimits(_user, _limit, _limit);
+
+    vm.startPrank(_user);
+    _xerc20.mint(_user, _amount0);
+
+    skip(_timePassed);
+    //vm.expectRevert(stdError.arithmeticError);
+    _xerc20.mint(_user, _amount0);
     vm.stopPrank();
   }
 


### PR DESCRIPTION
Here at [BootNode](https://www.bootnode.dev/), using this implementation we found a condition were every mint fails. Upon further investigation, we encounter that when limits are set over MAX_UINT256/2 an overflowing issue arises.


In `_getCurrentLimit` there are 3 branches, the first two returns the maxLimit, either because there were no mints or if the day's replenishment quota has been met, the overflow issue appears in the third branch.

```solidity
function _getCurrentLimit(
    uint256 _currentLimit,
    uint256 _maxLimit,
    uint256 _timestamp,
    uint256 _ratePerSecond
  ) internal view returns (uint256 _limit) {
    _limit = _currentLimit;
    if (_limit == _maxLimit) {
      return _limit;
    } else if (_timestamp + _DURATION <= block.timestamp) {
      _limit = _maxLimit;
    } else if (_timestamp + _DURATION > block.timestamp) {
      uint256 _timePassed = block.timestamp - _timestamp;
      uint256 _calculatedLimit = _limit + (_timePassed * _ratePerSecond);
      _limit = _calculatedLimit > _maxLimit ? _maxLimit : _calculatedLimit;
    }
  }
```
`_timestamp` is always on the past of  `block.timestamp`, `timestamp > block.timestamp - DURATION` => `timestamp: (block.timestamp - DURATION, block.timestamp]`. From this we can see that `_timePassed` is `[0,DURATION)`. We're going to consider the upper bound of `_timePassed`: `DURATION`.

On the next line; we can write `_ratePerSecond` as `maxLimit/DURATION`. Substituting this on the expression for `_calculatedLimit`:

```
_limit + (DURATION * maxLimit / DURATION)
```

Cancelling DURATION, we have _limit, that is `[0, maxLimit)` or `[0,maxLimit-1]` because at this point someone already minted, so we got something like `~= maxLimit-1 + maxLimit` that overflows  `uint256`. $2\mathrm{maxLimit} - 1 \le \mathrm{MAXUINT256}$ or $\mathrm{maxLimit} \le \frac{\mathrm{MAXUINT256}+1}{2} \le \frac{\mathrm{MAXUINT256}}{2}+1$


For this setting of limits (or some governor using values bigger than that limit) we get an overflow / DoS until `DURATION`  had passed. Even trying to set `setLimits` to fix this before that period will not work because also uses `_getCurrentLimit`.

On [this commit](https://github.com/defi-wonderland/xERC20/commit/07849a2d9e71c9017930073513b1f249d94e999a) there is a test for the edge case just explained.


