### PR TITLE
Fix: bugs, code coverage, lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ out/*/*
 # Keep the latest deployment only
 broadcast/**
 !broadcast/**/run-latest.json
+
+# Coverage
+lcov.info

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "forge build --via-ir",
     "build:optimized": "FOUNDRY_PROFILE=optimized forge build",
     "coverage": "forge coverage --match-contract Unit",
+    "coverage:report": "yarn coverage --report lcov",
     "postinstall": "forge install",
     "lint:check": "yarn lint:sol-tests && yarn lint:sol-logic && forge fmt check",
     "lint:fix": "sort-package-json && forge fmt && yarn lint:sol-tests --fix && yarn lint:sol-logic --fix",
@@ -32,7 +33,7 @@
     "test": "forge test -vvv --via-ir",
     "test:e2e": "forge test --match-contract E2E -vvv --via-ir",
     "test:unit": "forge test --match-contract Unit -vvv --via-ir",
-    "test:unit:deep": "FOUNDRY_FUZZ_RUNS=5000 yarn test:unit --via-ir"
+    "test:unit:deep": "FOUNDRY_FUZZ_RUNS=5000 yarn test:unit"
   },
   "lint-staged": {
     "*.{js,css,md,ts,sol}": "forge fmt",

--- a/solidity/contracts/XERC20Factory.sol
+++ b/solidity/contracts/XERC20Factory.sol
@@ -35,7 +35,6 @@ contract XERC20Factory is IXERC20Factory {
    * @param _bridges The array of bridges that you are adding (optional, can be an empty array)
    * @return _xerc20 The address of the xerc20
    */
-
   function deployXERC20(
     string memory _name,
     string memory _symbol,
@@ -57,7 +56,6 @@ contract XERC20Factory is IXERC20Factory {
    * @param _isNative Whether or not the base token is the native (gas) token of the chain. Eg: MATIC for polygon chain
    * @return _lockbox The address of the lockbox
    */
-
   function deployLockbox(
     address _xerc20,
     address _baseToken,
@@ -85,7 +83,6 @@ contract XERC20Factory is IXERC20Factory {
    * @param _bridges The array of burners that you are adding (optional, can be an empty array)
    * @return _xerc20 The address of the xerc20
    */
-
   function _deployXERC20(
     string memory _name,
     string memory _symbol,

--- a/solidity/contracts/XERC20Lockbox.sol
+++ b/solidity/contracts/XERC20Lockbox.sol
@@ -24,7 +24,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
   /**
    * @notice Whether the ERC20 token is the native gas token of this chain
    */
-
   bool public immutable IS_NATIVE;
 
   /**
@@ -34,7 +33,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    * @param _erc20 The address of the ERC20 contract
    * @param _isNative Whether the ERC20 token is the native gas token of this chain or not
    */
-
   constructor(address _xerc20, address _erc20, bool _isNative) {
     XERC20 = IXERC20(_xerc20);
     ERC20 = IERC20(_erc20);
@@ -44,7 +42,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
   /**
    * @notice Deposit native tokens into the lockbox
    */
-
   function depositNative() public payable {
     if (!IS_NATIVE) revert IXERC20Lockbox_NotNative();
 
@@ -56,7 +53,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    *
    * @param _amount The amount of tokens to deposit
    */
-
   function deposit(uint256 _amount) external {
     if (IS_NATIVE) revert IXERC20Lockbox_Native();
 
@@ -69,7 +65,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    * @param _to The user to send the XERC20 to
    * @param _amount The amount of tokens to deposit
    */
-
   function depositTo(address _to, uint256 _amount) external {
     if (IS_NATIVE) revert IXERC20Lockbox_Native();
 
@@ -81,7 +76,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    *
    * @param _to The user to send the XERC20 to
    */
-
   function depositNativeTo(address _to) public payable {
     if (!IS_NATIVE) revert IXERC20Lockbox_NotNative();
 
@@ -93,7 +87,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    *
    * @param _amount The amount of tokens to withdraw
    */
-
   function withdraw(uint256 _amount) external {
     _withdraw(msg.sender, _amount);
   }
@@ -104,7 +97,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    * @param _to The user to withdraw to
    * @param _amount The amount of tokens to withdraw
    */
-
   function withdrawTo(address _to, uint256 _amount) external {
     _withdraw(_to, _amount);
   }
@@ -115,7 +107,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    * @param _to The user to withdraw to
    * @param _amount The amount of tokens to withdraw
    */
-
   function _withdraw(address _to, uint256 _amount) internal {
     emit Withdraw(_to, _amount);
 
@@ -135,7 +126,6 @@ contract XERC20Lockbox is IXERC20Lockbox {
    * @param _to The address to send the XERC20 to
    * @param _amount The amount of tokens to deposit
    */
-
   function _deposit(address _to, uint256 _amount) internal {
     if (!IS_NATIVE) {
       ERC20.safeTransferFrom(msg.sender, address(this), _amount);

--- a/solidity/interfaces/IXERC20Factory.sol
+++ b/solidity/interfaces/IXERC20Factory.sol
@@ -7,7 +7,6 @@ interface IXERC20Factory {
    *
    * @param _xerc20 The address of the xerc20
    */
-
   event XERC20Deployed(address _xerc20);
 
   /**
@@ -15,25 +14,21 @@ interface IXERC20Factory {
    *
    * @param _lockbox The address of the lockbox
    */
-
   event LockboxDeployed(address _lockbox);
 
   /**
    * @notice Reverts when a non-owner attempts to call
    */
-
   error IXERC20Factory_NotOwner();
 
   /**
    * @notice Reverts when a lockbox is trying to be deployed from a malicious address
    */
-
   error IXERC20Factory_BadTokenAddress();
 
   /**
    * @notice Reverts when a lockbox is already deployed
    */
-
   error IXERC20Factory_LockboxAlreadyDeployed();
 
   /**
@@ -51,7 +46,6 @@ interface IXERC20Factory {
    * @param _bridges The array of burners that you are adding (optional, can be an empty array)
    * @return _xerc20 The address of the xerc20
    */
-
   function deployXERC20(
     string memory _name,
     string memory _symbol,
@@ -68,7 +62,6 @@ interface IXERC20Factory {
    * @param _isNative Whether or not the base token is native
    * @return _lockbox The address of the lockbox
    */
-
   function deployLockbox(
     address _xerc20,
     address _baseToken,

--- a/solidity/interfaces/IXERC20Lockbox.sol
+++ b/solidity/interfaces/IXERC20Lockbox.sol
@@ -8,7 +8,6 @@ interface IXERC20Lockbox {
    * @param _sender The address of the user who deposited
    * @param _amount The amount of tokens deposited
    */
-
   event Deposit(address _sender, uint256 _amount);
 
   /**
@@ -17,25 +16,21 @@ interface IXERC20Lockbox {
    * @param _sender The address of the user who withdrew
    * @param _amount The amount of tokens withdrawn
    */
-
   event Withdraw(address _sender, uint256 _amount);
 
   /**
    * @notice Reverts when a user tries to deposit native tokens on a non-native lockbox
    */
-
   error IXERC20Lockbox_NotNative();
 
   /**
    * @notice Reverts when a user tries to deposit non-native tokens on a native lockbox
    */
-
   error IXERC20Lockbox_Native();
 
   /**
    * @notice Reverts when a user tries to withdraw and the call fails
    */
-
   error IXERC20Lockbox_WithdrawFailed();
 
   /**
@@ -43,7 +38,6 @@ interface IXERC20Lockbox {
    *
    * @param _amount The amount of tokens to deposit
    */
-
   function deposit(uint256 _amount) external;
 
   /**
@@ -52,7 +46,6 @@ interface IXERC20Lockbox {
    * @param _user The user to send the XERC20 to
    * @param _amount The amount of tokens to deposit
    */
-
   function depositTo(address _user, uint256 _amount) external;
 
   /**
@@ -60,7 +53,6 @@ interface IXERC20Lockbox {
    *
    * @param _user The user to send the XERC20 to
    */
-
   function depositNativeTo(address _user) external payable;
 
   /**
@@ -68,7 +60,6 @@ interface IXERC20Lockbox {
    *
    * @param _amount The amount of tokens to withdraw
    */
-
   function withdraw(uint256 _amount) external;
 
   /**
@@ -77,6 +68,5 @@ interface IXERC20Lockbox {
    * @param _user The user to withdraw to
    * @param _amount The amount of tokens to withdraw
    */
-
   function withdrawTo(address _user, uint256 _amount) external;
 }

--- a/solidity/test/unit/XERC20.t.sol
+++ b/solidity/test/unit/XERC20.t.sol
@@ -69,7 +69,7 @@ contract UnitMintBurn is Base {
   }
 
   function testMint(uint256 _amount) public {
-    vm.assume(_amount > 0);
+    _amount = bound(_amount, 1, 1e40);
 
     vm.prank(_owner);
     _xerc20.setLimits(_user, _amount, 0);
@@ -129,6 +129,7 @@ contract UnitMintBurn is Base {
 
 contract UnitCreateParams is Base {
   function testChangeLimit(uint256 _amount, address _randomAddr) public {
+    _amount = bound(_amount, 1, 1e40);
     vm.assume(_randomAddr != address(0));
     vm.startPrank(_owner);
     _xerc20.setLimits(_randomAddr, _amount, _amount);
@@ -150,9 +151,9 @@ contract UnitCreateParams is Base {
     address _user1,
     address _user2
   ) public {
-    vm.assume(_amount0 > 0);
-    vm.assume(_amount1 > 0);
-    vm.assume(_amount2 > 0);
+    _amount0 = bound(_amount0, 1, 1e40);
+    _amount1 = bound(_amount1, 1, 1e40);
+    _amount2 = bound(_amount2, 1, 1e40);
 
     vm.assume(_user0 != _user1 && _user1 != _user2 && _user0 != _user2);
     uint256[] memory _limits = new uint256[](3);
@@ -181,6 +182,7 @@ contract UnitCreateParams is Base {
   }
 
   function testchangeBridgeMintingLimitEmitsEvent(uint256 _limit, address _minter) public {
+    _limit = bound(_limit, 1, 1e40);
     vm.prank(_owner);
     vm.expectEmit(true, true, true, true);
     emit BridgeLimitsSet(_limit, 0, _minter);
@@ -188,6 +190,7 @@ contract UnitCreateParams is Base {
   }
 
   function testchangeBridgeBurningLimitEmitsEvent(uint256 _limit, address _minter) public {
+    _limit = bound(_limit, 1, 1e40);
     vm.prank(_owner);
     vm.expectEmit(true, true, true, true);
     emit BridgeLimitsSet(0, _limit, _minter);
@@ -195,7 +198,7 @@ contract UnitCreateParams is Base {
   }
 
   function testSettingLimitsToUnapprovedUser(uint256 _amount) public {
-    vm.assume(_amount > 0);
+    _amount = bound(_amount, 1, 1e40);
 
     vm.startPrank(_owner);
     _xerc20.setLimits(_minter, _amount, _amount);
@@ -206,7 +209,7 @@ contract UnitCreateParams is Base {
   }
 
   function testUseLimitsUpdatesLimit(uint256 _limit, address _minter) public {
-    vm.assume(_limit > 1e6);
+    _limit = bound(_limit, 1e6, 1e40);
     vm.assume(_minter != address(0));
     vm.warp(1_683_145_698); // current timestamp at the time of testing
 
@@ -226,6 +229,7 @@ contract UnitCreateParams is Base {
   }
 
   function testCurrentLimitIsMaxLimitIfUnused(uint256 _limit, address _minter) public {
+    _limit = bound(_limit, 1, 1e40);
     uint256 _currentTimestamp = 1_683_145_698;
     vm.warp(_currentTimestamp);
 
@@ -240,6 +244,7 @@ contract UnitCreateParams is Base {
   }
 
   function testCurrentLimitIsMaxLimitIfOver24Hours(uint256 _limit, address _minter) public {
+    _limit = bound(_limit, 1, 1e40);
     uint256 _currentTimestamp = 1_683_145_698;
     vm.warp(_currentTimestamp);
     vm.assume(_minter != address(0));
@@ -260,7 +265,7 @@ contract UnitCreateParams is Base {
   }
 
   function testLimitVestsLinearly(uint256 _limit, address _minter) public {
-    vm.assume(_limit > 1e6);
+    _limit = bound(_limit, 1e6, 1e40);
     vm.assume(_minter != address(0));
     uint256 _currentTimestamp = 1_683_145_698;
     vm.warp(_currentTimestamp);
@@ -390,6 +395,12 @@ contract UnitCreateParams is Base {
     assertEq(_xerc20.lockbox(), _lockbox);
   }
 
+  function testSetLockBoxRevert(address _lockbox) public {
+    vm.prank(_user);
+    vm.expectRevert(abi.encodeWithSelector(IXERC20.IXERC20_NotFactory.selector));
+    _xerc20.setLockbox(_lockbox);
+  }
+
   function testSetLockboxEmitsEvents(address _lockbox) public {
     vm.expectEmit(true, true, true, true);
     emit LockboxSet(_lockbox);
@@ -411,7 +422,7 @@ contract UnitCreateParams is Base {
   }
 
   function testRemoveBridge(uint256 _limit) public {
-    vm.assume(_limit > 0);
+    _limit = bound(_limit, 1, 1e40);
 
     vm.startPrank(_owner);
     _xerc20.setLimits(_minter, _limit, _limit);

--- a/solidity/test/unit/XERC20Factory.t.sol
+++ b/solidity/test/unit/XERC20Factory.t.sol
@@ -34,8 +34,23 @@ contract UnitDeploy is Base {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
-    assertEq(XERC20(_xerc20).name(), 'Test');
+    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters));
+    assertEq(_xerc20.name(), 'Test');
+    assertEq(_xerc20.symbol(), 'TST');
+    assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
+  }
+
+  function testDeploymentWithLimitsAndMinters() public {
+    uint256[] memory _limits = new uint256[](1);
+    address[] memory _minters = new address[](1);
+
+    _limits[0] = 1e18;
+    _minters[0] = _user;
+
+    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters));
+    assertEq(_xerc20.name(), 'Test');
+    assertEq(_xerc20.symbol(), 'TST');
+    assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
   }
 
   function testRevertsWhenAddressIsTaken() public {


### PR DESCRIPTION
## Changes
- Fixed error in script `test:unit:deep` regarding double usage of `--via-ir`.
- Fixed fuzzing errors related to `setLimits()` input bounds.
- Increased code coverage of unit tests to 100%.
- Added `lcov.info` to `.gitignore`
- Ran `yarn lint:fix`.

## Code Coverage
### Before
<img width="970" alt="Before" src="https://github.com/defi-wonderland/xERC20/assets/111397465/bc2dbce2-98d5-4686-84df-86ea50d78776">

### After
<img width="970" alt="After" src="https://github.com/defi-wonderland/xERC20/assets/111397465/b14626d5-762e-4abf-a169-6bbffb4cde3e">
