### PR TITLE
refactor: custom decimals

### DIFF
--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -60,8 +60,8 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @notice Returns the number of decimals of the token
    * @return _decimals The number of decimals
    */
-  function decimals() public view override returns (uint8) {
-    return DECIMALS;
+  function decimals() public view override returns (uint8 _decimals) {
+    _decimals = DECIMALS;
   }
 
   /**

--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -18,6 +18,11 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
   uint256 private constant _MAX_LIMIT = type(uint256).max >> 1;
 
   /**
+   * @notice The number of decimals of the token
+   */
+  uint8 public immutable DECIMALS;
+
+  /**
    * @notice The address of the factory which deployed this contract
    */
   address public immutable FACTORY;
@@ -37,11 +42,26 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    *
    * @param _name The name of the token
    * @param _symbol The symbol of the token
+   * @param _decimals The number of decimals of the token
    * @param _factory The factory which deployed this contract
    */
-  constructor(string memory _name, string memory _symbol, address _factory) ERC20(_name, _symbol) ERC20Permit(_name) {
+  constructor(
+    string memory _name,
+    string memory _symbol,
+    uint8 _decimals,
+    address _factory
+  ) ERC20(_name, _symbol) ERC20Permit(_name) {
     _transferOwnership(_factory);
     FACTORY = _factory;
+    DECIMALS = _decimals;
+  }
+
+  /**
+   * @notice Returns the number of decimals of the token
+   * @return _decimals The number of decimals
+   */
+  function decimals() public view override returns (uint8) {
+    return DECIMALS;
   }
 
   /**

--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -13,6 +13,11 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
   uint256 private constant _DURATION = 1 days;
 
   /**
+   * @notice The maximum limit of a bridge
+   */
+  uint256 private constant _MAX_LIMIT = type(uint256).max >> 1;
+
+  /**
    * @notice The address of the factory which deployed this contract
    */
   address public immutable FACTORY;
@@ -68,7 +73,9 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    *
    * @param _lockbox The address of the lockbox
    */
-  function setLockbox(address _lockbox) public {
+  function setLockbox(
+    address _lockbox
+  ) public {
     if (msg.sender != FACTORY) revert IXERC20_NotFactory();
     lockbox = _lockbox;
 
@@ -83,7 +90,7 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge The address of the bridge we are setting the limits too
    */
   function setLimits(address _bridge, uint256 _mintingLimit, uint256 _burningLimit) external onlyOwner {
-    if (_mintingLimit > (type(uint256).max / 2) || _burningLimit > (type(uint256).max / 2)) {
+    if (_mintingLimit > _MAX_LIMIT || _burningLimit > _MAX_LIMIT) {
       revert IXERC20_LimitsTooHigh();
     }
 
@@ -98,7 +105,9 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-  function mintingMaxLimitOf(address _bridge) public view returns (uint256 _limit) {
+  function mintingMaxLimitOf(
+    address _bridge
+  ) public view returns (uint256 _limit) {
     _limit = bridges[_bridge].minterParams.maxLimit;
   }
 
@@ -108,7 +117,9 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-  function burningMaxLimitOf(address _bridge) public view returns (uint256 _limit) {
+  function burningMaxLimitOf(
+    address _bridge
+  ) public view returns (uint256 _limit) {
     _limit = bridges[_bridge].burnerParams.maxLimit;
   }
 
@@ -118,7 +129,9 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-  function mintingCurrentLimitOf(address _bridge) public view returns (uint256 _limit) {
+  function mintingCurrentLimitOf(
+    address _bridge
+  ) public view returns (uint256 _limit) {
     _limit = _getCurrentLimit(
       bridges[_bridge].minterParams.currentLimit,
       bridges[_bridge].minterParams.maxLimit,
@@ -133,7 +146,9 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _bridge the bridge we are viewing the limits of
    * @return _limit The limit the bridge has
    */
-  function burningCurrentLimitOf(address _bridge) public view returns (uint256 _limit) {
+  function burningCurrentLimitOf(
+    address _bridge
+  ) public view returns (uint256 _limit) {
     _limit = _getCurrentLimit(
       bridges[_bridge].burnerParams.currentLimit,
       bridges[_bridge].burnerParams.maxLimit,

--- a/solidity/contracts/XERC20Factory.sol
+++ b/solidity/contracts/XERC20Factory.sol
@@ -32,6 +32,7 @@ contract XERC20Factory is IXERC20Factory {
    * @param _name The name of the token
    * @param _symbol The symbol of the token
    * @param _decimals The number of decimals of the token
+   * @param _owner The owner of the xerc20
    * @param _minterLimits The array of limits that you are adding (optional, can be an empty array)
    * @param _burnerLimits The array of limits that you are adding (optional, can be an empty array)
    * @param _bridges The array of bridges that you are adding (optional, can be an empty array)
@@ -41,45 +42,48 @@ contract XERC20Factory is IXERC20Factory {
     string memory _name,
     string memory _symbol,
     uint8 _decimals,
+    address _owner,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges
   ) external returns (address _xerc20) {
-    _xerc20 = _deployXERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges);
-
-    emit XERC20Deployed(_xerc20);
+    _xerc20 = _deployXERC20(_name, _symbol, _decimals, _owner, _minterLimits, _burnerLimits, _bridges);
   }
 
   /**
-   * @notice Deploys an XERC20Lockbox contract using CREATE3
+   * @notice Deploys an XERC20 and an XERC20Lockbox contract using CREATE3
    *
    * @dev When deploying a lockbox for the gas token of the chain, then, the base token needs to be address(0)
-   * @param _xerc20 The address of the xerc20 that you want to deploy a lockbox for
+   * @param _name The name of the token
+   * @param _symbol The symbol of the token
+   * @param _owner The owner of the xerc20
+   * @param _minterLimits The array of limits that you are adding (optional, can be an empty array)
+   * @param _burnerLimits The array of limits that you are adding (optional, can be an empty array)
+   * @param _bridges The array of bridges that you are adding (optional, can be an empty array)
    * @param _baseToken The address of the base token that you want to lock
    * @param _isNative Whether or not the base token is the native (gas) token of the chain. Eg: MATIC for polygon chain
+   * @return _xerc20 The address of the xerc20
    * @return _lockbox The address of the lockbox
    */
-  function deployLockbox(
-    address _xerc20,
+  function deployXERC20WithLockbox(
+    string memory _name,
+    string memory _symbol,
+    address _owner,
+    uint256[] memory _minterLimits,
+    uint256[] memory _burnerLimits,
+    address[] memory _bridges,
     address _baseToken,
     bool _isNative
-  ) external returns (address payable _lockbox) {
-    if ((_baseToken == address(0)) != _isNative) {
-      revert IXERC20Factory_BadTokenAddress();
-    }
+  ) external returns (address _xerc20, address payable _lockbox) {
+    if ((_baseToken == address(0)) != _isNative) revert IXERC20Factory_BadTokenAddress();
 
-    if (!_isNative) {
-      if (IERC20Metadata(_xerc20).decimals() != IERC20Metadata(_baseToken).decimals()) {
-        revert IXERC20Factory_TokenDecimalsMismatch();
-      }
-    }
+    uint8 _decimals = _isNative ? 18 : IERC20Metadata(_baseToken).decimals();
 
-    if (XERC20(_xerc20).owner() != msg.sender) revert IXERC20Factory_NotOwner();
+    _xerc20 = _deployXERC20(_name, _symbol, _decimals, _owner, _minterLimits, _burnerLimits, _bridges);
+
     if (_lockboxRegistry[_xerc20] != address(0)) revert IXERC20Factory_LockboxAlreadyDeployed();
 
     _lockbox = _deployLockbox(_xerc20, _baseToken, _isNative);
-
-    emit LockboxDeployed(_lockbox);
   }
 
   /**
@@ -97,6 +101,7 @@ contract XERC20Factory is IXERC20Factory {
     string memory _name,
     string memory _symbol,
     uint8 _decimals,
+    address _owner,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges
@@ -117,7 +122,9 @@ contract XERC20Factory is IXERC20Factory {
       XERC20(_xerc20).setLimits(_bridges[_i], _minterLimits[_i], _burnerLimits[_i]);
     }
 
-    XERC20(_xerc20).transferOwnership(msg.sender);
+    XERC20(_xerc20).transferOwnership(_owner);
+
+    emit XERC20Deployed(_xerc20);
   }
 
   /**
@@ -143,5 +150,7 @@ contract XERC20Factory is IXERC20Factory {
     XERC20(_xerc20).setLockbox(address(_lockbox));
     EnumerableSet.add(_lockboxRegistryArray, _lockbox);
     _lockboxRegistry[_xerc20] = _lockbox;
+
+    emit LockboxDeployed(_lockbox);
   }
 }

--- a/solidity/contracts/XERC20Factory.sol
+++ b/solidity/contracts/XERC20Factory.sol
@@ -5,6 +5,7 @@ import {XERC20} from '../contracts/XERC20.sol';
 import {IXERC20Factory} from '../interfaces/IXERC20Factory.sol';
 import {XERC20Lockbox} from '../contracts/XERC20Lockbox.sol';
 import {CREATE3} from 'isolmate/utils/CREATE3.sol';
+import {IERC20Metadata} from '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 
 contract XERC20Factory is IXERC20Factory {
@@ -30,6 +31,7 @@ contract XERC20Factory is IXERC20Factory {
    * @dev _limits and _minters must be the same length
    * @param _name The name of the token
    * @param _symbol The symbol of the token
+   * @param _decimals The number of decimals of the token
    * @param _minterLimits The array of limits that you are adding (optional, can be an empty array)
    * @param _burnerLimits The array of limits that you are adding (optional, can be an empty array)
    * @param _bridges The array of bridges that you are adding (optional, can be an empty array)
@@ -38,11 +40,12 @@ contract XERC20Factory is IXERC20Factory {
   function deployXERC20(
     string memory _name,
     string memory _symbol,
+    uint8 _decimals,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges
   ) external returns (address _xerc20) {
-    _xerc20 = _deployXERC20(_name, _symbol, _minterLimits, _burnerLimits, _bridges);
+    _xerc20 = _deployXERC20(_name, _symbol, _decimals, _minterLimits, _burnerLimits, _bridges);
 
     emit XERC20Deployed(_xerc20);
   }
@@ -65,6 +68,10 @@ contract XERC20Factory is IXERC20Factory {
       revert IXERC20Factory_BadTokenAddress();
     }
 
+    if (IERC20Metadata(_xerc20).decimals() != IERC20Metadata(_baseToken).decimals()) {
+      revert IXERC20Factory_TokenDecimalsMismatch();
+    }
+
     if (XERC20(_xerc20).owner() != msg.sender) revert IXERC20Factory_NotOwner();
     if (_lockboxRegistry[_xerc20] != address(0)) revert IXERC20Factory_LockboxAlreadyDeployed();
 
@@ -78,6 +85,7 @@ contract XERC20Factory is IXERC20Factory {
    * @dev _limits and _minters must be the same length
    * @param _name The name of the token
    * @param _symbol The symbol of the token
+   * @param _decimals The number of decimals of the token
    * @param _minterLimits The array of limits that you are adding (optional, can be an empty array)
    * @param _burnerLimits The array of limits that you are adding (optional, can be an empty array)
    * @param _bridges The array of burners that you are adding (optional, can be an empty array)
@@ -86,6 +94,7 @@ contract XERC20Factory is IXERC20Factory {
   function _deployXERC20(
     string memory _name,
     string memory _symbol,
+    uint8 _decimals,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges
@@ -94,9 +103,9 @@ contract XERC20Factory is IXERC20Factory {
     if (_minterLimits.length != _bridgesLength || _burnerLimits.length != _bridgesLength) {
       revert IXERC20Factory_InvalidLength();
     }
-    bytes32 _salt = keccak256(abi.encodePacked(_name, _symbol, msg.sender));
+    bytes32 _salt = keccak256(abi.encodePacked(_name, _symbol, _decimals, msg.sender));
     bytes memory _creation = type(XERC20).creationCode;
-    bytes memory _bytecode = abi.encodePacked(_creation, abi.encode(_name, _symbol, address(this)));
+    bytes memory _bytecode = abi.encodePacked(_creation, abi.encode(_name, _symbol, _decimals, address(this)));
 
     _xerc20 = CREATE3.deploy(_salt, _bytecode, 0);
 

--- a/solidity/contracts/XERC20Factory.sol
+++ b/solidity/contracts/XERC20Factory.sol
@@ -64,12 +64,14 @@ contract XERC20Factory is IXERC20Factory {
     address _baseToken,
     bool _isNative
   ) external returns (address payable _lockbox) {
-    if ((_baseToken == address(0) && !_isNative) || (_isNative && _baseToken != address(0))) {
+    if ((_baseToken == address(0)) != _isNative) {
       revert IXERC20Factory_BadTokenAddress();
     }
 
-    if (IERC20Metadata(_xerc20).decimals() != IERC20Metadata(_baseToken).decimals()) {
-      revert IXERC20Factory_TokenDecimalsMismatch();
+    if (!_isNative) {
+      if (IERC20Metadata(_xerc20).decimals() != IERC20Metadata(_baseToken).decimals()) {
+        revert IXERC20Factory_TokenDecimalsMismatch();
+      }
     }
 
     if (XERC20(_xerc20).owner() != msg.sender) revert IXERC20Factory_NotOwner();

--- a/solidity/contracts/XERC20Factory.sol
+++ b/solidity/contracts/XERC20Factory.sol
@@ -81,8 +81,6 @@ contract XERC20Factory is IXERC20Factory {
 
     _xerc20 = _deployXERC20(_name, _symbol, _decimals, _owner, _minterLimits, _burnerLimits, _bridges);
 
-    if (_lockboxRegistry[_xerc20] != address(0)) revert IXERC20Factory_LockboxAlreadyDeployed();
-
     _lockbox = _deployLockbox(_xerc20, _baseToken, _isNative);
   }
 

--- a/solidity/contracts/XERC20Lockbox.sol
+++ b/solidity/contracts/XERC20Lockbox.sol
@@ -53,7 +53,9 @@ contract XERC20Lockbox is IXERC20Lockbox {
    *
    * @param _amount The amount of tokens to deposit
    */
-  function deposit(uint256 _amount) external {
+  function deposit(
+    uint256 _amount
+  ) external {
     if (IS_NATIVE) revert IXERC20Lockbox_Native();
 
     _deposit(msg.sender, _amount);
@@ -76,7 +78,9 @@ contract XERC20Lockbox is IXERC20Lockbox {
    *
    * @param _to The user to send the XERC20 to
    */
-  function depositNativeTo(address _to) public payable {
+  function depositNativeTo(
+    address _to
+  ) public payable {
     if (!IS_NATIVE) revert IXERC20Lockbox_NotNative();
 
     _deposit(_to, msg.value);
@@ -87,7 +91,9 @@ contract XERC20Lockbox is IXERC20Lockbox {
    *
    * @param _amount The amount of tokens to withdraw
    */
-  function withdraw(uint256 _amount) external {
+  function withdraw(
+    uint256 _amount
+  ) external {
     _withdraw(msg.sender, _amount);
   }
 

--- a/solidity/interfaces/IXERC20Factory.sol
+++ b/solidity/interfaces/IXERC20Factory.sol
@@ -37,41 +37,50 @@ interface IXERC20Factory {
   error IXERC20Factory_InvalidLength();
 
   /**
-   * @notice Reverts when the decimals of the token and the base token mismatch
-   */
-  error IXERC20Factory_TokenDecimalsMismatch();
-
-  /**
    * @notice Deploys an XERC20 contract using CREATE3
    * @dev _limits and _minters must be the same length
    * @param _name The name of the token
    * @param _symbol The symbol of the token
    * @param _decimals The number of decimals of the token
-   * @param _minterLimits The array of minter limits that you are adding (optional, can be an empty array)
-   * @param _burnerLimits The array of burning limits that you are adding (optional, can be an empty array)
-   * @param _bridges The array of burners that you are adding (optional, can be an empty array)
+   * @param _owner The owner of the xerc20
+   * @param _minterLimits The array of limits that you are adding (optional, can be an empty array)
+   * @param _burnerLimits The array of limits that you are adding (optional, can be an empty array)
+   * @param _bridges The array of bridges that you are adding (optional, can be an empty array)
    * @return _xerc20 The address of the xerc20
    */
   function deployXERC20(
     string memory _name,
     string memory _symbol,
     uint8 _decimals,
+    address _owner,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges
   ) external returns (address _xerc20);
 
   /**
-   * @notice Deploys an XERC20Lockbox contract using CREATE3
+   * @notice Deploys an XERC20 and an XERC20Lockbox contract using CREATE3
    *
-   * @param _xerc20 The address of the xerc20 that you want to deploy a lockbox for
+   * @dev When deploying a lockbox for the gas token of the chain, then, the base token needs to be address(0)
+   * @param _name The name of the token
+   * @param _symbol The symbol of the token
+   * @param _owner The owner of the xerc20
+   * @param _minterLimits The array of limits that you are adding (optional, can be an empty array)
+   * @param _burnerLimits The array of limits that you are adding (optional, can be an empty array)
+   * @param _bridges The array of bridges that you are adding (optional, can be an empty array)
    * @param _baseToken The address of the base token that you want to lock
-   * @param _isNative Whether or not the base token is native
+   * @param _isNative Whether or not the base token is the native (gas) token of the chain. Eg: MATIC for polygon chain
+   * @return _xerc20 The address of the xerc20
    * @return _lockbox The address of the lockbox
    */
-  function deployLockbox(
-    address _xerc20,
+  function deployXERC20WithLockbox(
+    string memory _name,
+    string memory _symbol,
+    address _owner,
+    uint256[] memory _minterLimits,
+    uint256[] memory _burnerLimits,
+    address[] memory _bridges,
     address _baseToken,
     bool _isNative
-  ) external returns (address payable _lockbox);
+  ) external returns (address _xerc20, address payable _lockbox);
 }

--- a/solidity/interfaces/IXERC20Factory.sol
+++ b/solidity/interfaces/IXERC20Factory.sol
@@ -27,11 +27,6 @@ interface IXERC20Factory {
   error IXERC20Factory_BadTokenAddress();
 
   /**
-   * @notice Reverts when a lockbox is already deployed
-   */
-  error IXERC20Factory_LockboxAlreadyDeployed();
-
-  /**
    * @notice Reverts when a the length of arrays sent is incorrect
    */
   error IXERC20Factory_InvalidLength();

--- a/solidity/interfaces/IXERC20Factory.sol
+++ b/solidity/interfaces/IXERC20Factory.sol
@@ -37,10 +37,16 @@ interface IXERC20Factory {
   error IXERC20Factory_InvalidLength();
 
   /**
+   * @notice Reverts when the decimals of the token and the base token mismatch
+   */
+  error IXERC20Factory_TokenDecimalsMismatch();
+
+  /**
    * @notice Deploys an XERC20 contract using CREATE3
    * @dev _limits and _minters must be the same length
    * @param _name The name of the token
    * @param _symbol The symbol of the token
+   * @param _decimals The number of decimals of the token
    * @param _minterLimits The array of minter limits that you are adding (optional, can be an empty array)
    * @param _burnerLimits The array of burning limits that you are adding (optional, can be an empty array)
    * @param _bridges The array of burners that you are adding (optional, can be an empty array)
@@ -49,6 +55,7 @@ interface IXERC20Factory {
   function deployXERC20(
     string memory _name,
     string memory _symbol,
+    uint8 _decimals,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
     address[] memory _bridges

--- a/solidity/scripts/XERC20Deploy.sol
+++ b/solidity/scripts/XERC20Deploy.sol
@@ -69,14 +69,24 @@ contract XERC20Deploy is Script, ScriptingLibrary {
         _mintLimits[_bridgeIndex] = _bridgeDetails[_bridgeIndex].mintLimit;
       }
 
-      // deploy xerc20
-      address _xerc20 =
-        factory.deployXERC20(_data.name, _data.symbol, _data.decimals, _mintLimits, _burnLimits, _bridges);
-
-      // deploy lockbox if needed
+      // deploy xerc20 and lockbox if needed
+      address _xerc20;
       address _lockbox;
       if (_chainDetails.erc20 != address(0) && !_chainDetails.isNativeGasToken) {
-        _lockbox = factory.deployLockbox(_xerc20, _chainDetails.erc20, _chainDetails.isNativeGasToken);
+        (_xerc20, _lockbox) = factory.deployXERC20WithLockbox(
+          _data.name,
+          _data.symbol,
+          address(this),
+          _mintLimits,
+          _burnLimits,
+          _bridges,
+          _chainDetails.erc20,
+          _chainDetails.isNativeGasToken
+        );
+      } else {
+        _xerc20 = factory.deployXERC20(
+          _data.name, _data.symbol, _data.decimals, address(this), _mintLimits, _burnLimits, _bridges
+        );
       }
 
       // transfer xerc20 ownership to the governor

--- a/solidity/scripts/XERC20Deploy.sol
+++ b/solidity/scripts/XERC20Deploy.sol
@@ -32,6 +32,7 @@ struct DeploymentConfig {
   ChainDetails[] chainDetails;
   string name; // The name to use for the xERC20
   string symbol; // The symbol to use for the xERC20
+  uint8 decimals; // The number of decimals of the token
 }
 
 contract XERC20Deploy is Script, ScriptingLibrary {
@@ -69,7 +70,8 @@ contract XERC20Deploy is Script, ScriptingLibrary {
       }
 
       // deploy xerc20
-      address _xerc20 = factory.deployXERC20(_data.name, _data.symbol, _mintLimits, _burnLimits, _bridges);
+      address _xerc20 =
+        factory.deployXERC20(_data.name, _data.symbol, _data.decimals, _mintLimits, _burnLimits, _bridges);
 
       // deploy lockbox if needed
       address _lockbox;

--- a/solidity/scripts/XERC20Deploy.sol
+++ b/solidity/scripts/XERC20Deploy.sol
@@ -32,7 +32,7 @@ struct DeploymentConfig {
   ChainDetails[] chainDetails;
   string name; // The name to use for the xERC20
   string symbol; // The symbol to use for the xERC20
-  uint8 decimals; // The number of decimals of the token
+  uint8 decimals; // The number of decimals for the token
 }
 
 contract XERC20Deploy is Script, ScriptingLibrary {

--- a/solidity/scripts/xerc20-deployment-config.json
+++ b/solidity/scripts/xerc20-deployment-config.json
@@ -1,19 +1,20 @@
 {
-    "name": "Test",
-    "symbol": "TST",
-    "chainDetails": [
+  "name": "Test",
+  "symbol": "TST",
+  "decimals": 18,
+  "chainDetails": [
+    {
+      "rpcEnvName": "ETHEREUM_GOERLI_RPC",
+      "erc20": "0x0000000000000000000000000000000000000001",
+      "governor": "0x0000000000000000000000000000000000000002",
+      "isNativeGasToken": false,
+      "bridgeDetails": [
         {
-            "rpcEnvName": "ETHEREUM_GOERLI_RPC",
-            "erc20": "0x0000000000000000000000000000000000000001",
-            "governor": "0x0000000000000000000000000000000000000002",
-            "isNativeGasToken": false,
-            "bridgeDetails": [
-                {
-                    "bridge": "0x0000000000000000000000000000000000000003",
-                    "burnLimit": 1000e18,
-                    "mintLimit": 1000e18
-                }
-            ]
+          "bridge": "0x0000000000000000000000000000000000000003",
+          "burnLimit": 1000e18,
+          "mintLimit": 1000e18
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/solidity/test/e2e/Common.sol
+++ b/solidity/test/e2e/Common.sol
@@ -33,7 +33,8 @@ contract CommonE2EBase is Test {
 
     vm.startPrank(_owner);
     _xerc20Factory = new XERC20Factory();
-    address _token = _xerc20Factory.deployXERC20(_dai.name(), _dai.symbol(), _minterLimits, _burnerLimits, _bridges);
+    address _token =
+      _xerc20Factory.deployXERC20(_dai.name(), _dai.symbol(), _dai.decimals(), _minterLimits, _burnerLimits, _bridges);
     address payable _lock = _xerc20Factory.deployLockbox(_token, address(_dai), false);
 
     _xerc20 = XERC20(_token);

--- a/solidity/test/e2e/Common.sol
+++ b/solidity/test/e2e/Common.sol
@@ -33,9 +33,9 @@ contract CommonE2EBase is Test {
 
     vm.startPrank(_owner);
     _xerc20Factory = new XERC20Factory();
-    address _token =
-      _xerc20Factory.deployXERC20(_dai.name(), _dai.symbol(), _dai.decimals(), _minterLimits, _burnerLimits, _bridges);
-    address payable _lock = _xerc20Factory.deployLockbox(_token, address(_dai), false);
+    (address _token, address payable _lock) = _xerc20Factory.deployXERC20WithLockbox(
+      _dai.name(), _dai.symbol(), _owner, _minterLimits, _burnerLimits, _bridges, address(_dai), false
+    );
 
     _xerc20 = XERC20(_token);
     _lockbox = XERC20Lockbox(_lock);

--- a/solidity/test/e2e/XERC20Factory.t.sol
+++ b/solidity/test/e2e/XERC20Factory.t.sol
@@ -20,7 +20,7 @@ contract E2EDeployment is CommonE2EBase {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    address _token = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    address _token = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
     address _lock = _xerc20Factory.deployLockbox(_token, address(_dai), false);
 
     assertEq(address(XERC20Lockbox(payable(_lock)).XERC20()), address(_token));

--- a/solidity/test/e2e/XERC20Factory.t.sol
+++ b/solidity/test/e2e/XERC20Factory.t.sol
@@ -20,8 +20,8 @@ contract E2EDeployment is CommonE2EBase {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    address _token = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
-    address _lock = _xerc20Factory.deployLockbox(_token, address(_dai), false);
+    (address _token, address _lock) =
+      _xerc20Factory.deployXERC20WithLockbox('Test', 'TST', _owner, _limits, _limits, _minters, address(_dai), false);
 
     assertEq(address(XERC20Lockbox(payable(_lock)).XERC20()), address(_token));
     assertEq(address(XERC20Lockbox(payable(_lock)).ERC20()), address(_dai));

--- a/solidity/test/unit/XERC20.t.sol
+++ b/solidity/test/unit/XERC20.t.sol
@@ -18,7 +18,7 @@ abstract contract Base is Test {
 
   function setUp() public virtual {
     vm.startPrank(_owner);
-    _xerc20 = new XERC20('Test', 'TST', _owner);
+    _xerc20 = new XERC20('Test', 'TST', 18, _owner);
     vm.stopPrank();
   }
 }
@@ -34,7 +34,9 @@ contract UnitNames is Base {
 }
 
 contract UnitMintBurn is Base {
-  function testMintRevertsIfNotApprove(uint256 _amount) public {
+  function testMintRevertsIfNotApprove(
+    uint256 _amount
+  ) public {
     vm.assume(_amount > 0);
     vm.prank(_user);
     vm.expectRevert(IXERC20.IXERC20_NotHighEnoughLimits.selector);
@@ -68,7 +70,9 @@ contract UnitMintBurn is Base {
     vm.stopPrank();
   }
 
-  function testMint(uint256 _amount) public {
+  function testMint(
+    uint256 _amount
+  ) public {
     _amount = bound(_amount, 1, 1e40);
 
     vm.prank(_owner);
@@ -79,7 +83,9 @@ contract UnitMintBurn is Base {
     assertEq(_xerc20.balanceOf(_minter), _amount);
   }
 
-  function testBurn(uint256 _amount) public {
+  function testBurn(
+    uint256 _amount
+  ) public {
     _amount = bound(_amount, 1, 1e40);
     vm.startPrank(_owner);
     _xerc20.setLimits(_user, _amount, _amount);
@@ -94,7 +100,9 @@ contract UnitMintBurn is Base {
     assertEq(_xerc20.balanceOf(_user), 0);
   }
 
-  function testBurnRevertsWithoutApproval(uint256 _amount) public {
+  function testBurnRevertsWithoutApproval(
+    uint256 _amount
+  ) public {
     _amount = bound(_amount, 1, 1e40);
 
     vm.prank(_owner);
@@ -197,7 +205,9 @@ contract UnitCreateParams is Base {
     _xerc20.setLimits(_minter, 0, _limit);
   }
 
-  function testSettingLimitsToUnapprovedUser(uint256 _amount) public {
+  function testSettingLimitsToUnapprovedUser(
+    uint256 _amount
+  ) public {
     _amount = bound(_amount, 1, 1e40);
 
     vm.startPrank(_owner);
@@ -388,27 +398,35 @@ contract UnitCreateParams is Base {
     assertEq(_xerc20.burningCurrentLimitOf(_minter), 0);
   }
 
-  function testSetLockbox(address _lockbox) public {
+  function testSetLockbox(
+    address _lockbox
+  ) public {
     vm.prank(_owner);
     _xerc20.setLockbox(_lockbox);
 
     assertEq(_xerc20.lockbox(), _lockbox);
   }
 
-  function testSetLockBoxRevert(address _lockbox) public {
+  function testSetLockBoxRevert(
+    address _lockbox
+  ) public {
     vm.prank(_user);
     vm.expectRevert(abi.encodeWithSelector(IXERC20.IXERC20_NotFactory.selector));
     _xerc20.setLockbox(_lockbox);
   }
 
-  function testSetLockboxEmitsEvents(address _lockbox) public {
+  function testSetLockboxEmitsEvents(
+    address _lockbox
+  ) public {
     vm.expectEmit(true, true, true, true);
     emit LockboxSet(_lockbox);
     vm.prank(_owner);
     _xerc20.setLockbox(_lockbox);
   }
 
-  function testLockboxDoesntNeedMinterRights(address _lockbox) public {
+  function testLockboxDoesntNeedMinterRights(
+    address _lockbox
+  ) public {
     vm.assume(_lockbox != address(0));
     vm.prank(_owner);
     _xerc20.setLockbox(_lockbox);
@@ -421,7 +439,9 @@ contract UnitCreateParams is Base {
     vm.stopPrank();
   }
 
-  function testRemoveBridge(uint256 _limit) public {
+  function testRemoveBridge(
+    uint256 _limit
+  ) public {
     _limit = bound(_limit, 1, 1e40);
 
     vm.startPrank(_owner);

--- a/solidity/test/unit/XERC20.t.sol
+++ b/solidity/test/unit/XERC20.t.sol
@@ -33,6 +33,12 @@ contract UnitNames is Base {
   }
 }
 
+contract UnitDecimals is Base {
+  function testDecimals() public {
+    assertEq(18, _xerc20.decimals());
+  }
+}
+
 contract UnitMintBurn is Base {
   function testMintRevertsIfNotApprove(
     uint256 _amount

--- a/solidity/test/unit/XERC20Factory.t.sol
+++ b/solidity/test/unit/XERC20Factory.t.sol
@@ -135,6 +135,13 @@ contract UnitDeploy is Base {
     _xerc20Factory.deployLockbox(_erc20, address(100), true);
   }
 
+  function testLockboxDeploymentRevertsIfTokenDecimalsMismatch() public {
+    vm.expectRevert(IXERC20Factory.IXERC20Factory_TokenDecimalsMismatch.selector);
+    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
+    vm.mockCall(address(100), abi.encodeWithSignature('decimals()'), abi.encode(17));
+    _xerc20Factory.deployLockbox(_erc20, address(100), false);
+  }
+
   function testCantDeployLockboxTwice() public {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);

--- a/solidity/test/unit/XERC20Factory.t.sol
+++ b/solidity/test/unit/XERC20Factory.t.sol
@@ -36,7 +36,7 @@ contract UnitDeploy is Base {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters));
+    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _limits, _limits, _minters));
     assertEq(_xerc20.name(), 'Test');
     assertEq(_xerc20.symbol(), 'TST');
     assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
@@ -49,7 +49,7 @@ contract UnitDeploy is Base {
     _limits[0] = 1e18;
     _minters[0] = _user;
 
-    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters));
+    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _limits, _limits, _minters));
     assertEq(_xerc20.name(), 'Test');
     assertEq(_xerc20.symbol(), 'TST');
     assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
@@ -60,11 +60,11 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.prank(_owner);
-    _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _limits, _limits, _minters);
 
     vm.prank(_owner);
     vm.expectRevert('DEPLOYMENT_FAILED');
-    _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _limits, _limits, _minters);
   }
 
   function testComputedAddress() public {
@@ -74,7 +74,7 @@ contract UnitDeploy is Base {
     vm.startPrank(address(_owner));
     bytes32 _salt = keccak256(abi.encodePacked('Test', 'TST', uint8(18), _owner));
 
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
+    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _limits, _limits, _minters);
     vm.stopPrank();
     address _predictedAddress = _xerc20Factory.getDeployed(_salt);
 
@@ -87,8 +87,9 @@ contract UnitDeploy is Base {
 
     vm.startPrank(_owner);
     vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
-    address payable _lockbox = payable(_xerc20Factory.deployLockbox(_xerc20, _erc20, false));
+    (address _xerc20, address payable _lockbox) =
+      _xerc20Factory.deployXERC20WithLockbox('Test', 'TST', _owner, _limits, _limits, _minters, _erc20, false);
+
     vm.stopPrank();
 
     bytes32 _salt = keccak256(abi.encodePacked(_xerc20, _erc20, _owner));
@@ -102,57 +103,28 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.startPrank(_owner);
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
-
     vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
-    address payable _lockbox = payable(_xerc20Factory.deployLockbox(_xerc20, _erc20, false));
+    (address _xerc20, address payable _lockbox) =
+      _xerc20Factory.deployXERC20WithLockbox('Test', 'TST', _owner, _limits, _limits, _minters, _erc20, false);
     vm.stopPrank();
 
     assertEq(address(XERC20Lockbox(_lockbox).XERC20()), _xerc20);
     assertEq(address(XERC20Lockbox(_lockbox).ERC20()), _erc20);
   }
 
-  function testLockboxSingleDeploymentRevertsIfNotOwner() public {
+  function testLockboxDeploymentRevertsIfMaliciousAddress() public {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    vm.startPrank(_owner);
-    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
-    vm.stopPrank();
-
-    vm.expectRevert(IXERC20Factory.IXERC20Factory_NotOwner.selector);
-    _xerc20Factory.deployLockbox(_xerc20, _erc20, false);
-  }
-
-  function testLockboxDeploymentRevertsIfMaliciousAddress() public {
     vm.expectRevert(IXERC20Factory.IXERC20Factory_BadTokenAddress.selector);
-    _xerc20Factory.deployLockbox(_erc20, address(0), false);
+    _xerc20Factory.deployXERC20WithLockbox('Test', 'TST', _owner, _limits, _limits, _minters, address(0), false);
   }
 
   function testLockboxDeploymentRevertsIfInvalidParameters() public {
-    vm.expectRevert(IXERC20Factory.IXERC20Factory_BadTokenAddress.selector);
-    _xerc20Factory.deployLockbox(_erc20, address(100), true);
-  }
-
-  function testLockboxDeploymentRevertsIfTokenDecimalsMismatch() public {
-    vm.expectRevert(IXERC20Factory.IXERC20Factory_TokenDecimalsMismatch.selector);
-    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
-    vm.mockCall(address(100), abi.encodeWithSignature('decimals()'), abi.encode(17));
-    _xerc20Factory.deployLockbox(_erc20, address(100), false);
-  }
-
-  function testCantDeployLockboxTwice() public {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
-
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
-
-    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
-    _xerc20Factory.deployLockbox(_xerc20, _erc20, false);
-
-    vm.expectRevert(IXERC20Factory.IXERC20Factory_LockboxAlreadyDeployed.selector);
-    _xerc20Factory.deployLockbox(_xerc20, _erc20, false);
+    vm.expectRevert(IXERC20Factory.IXERC20Factory_BadTokenAddress.selector);
+    _xerc20Factory.deployXERC20WithLockbox('Test', 'TST', _owner, _limits, _limits, _minters, address(100), true);
   }
 
   function testNotParallelArraysRevert() public {
@@ -166,10 +138,10 @@ contract UnitDeploy is Base {
 
     vm.prank(_owner);
     vm.expectRevert(IXERC20Factory.IXERC20Factory_InvalidLength.selector);
-    _xerc20Factory.deployXERC20('Test', 'TST', 18, _minterLimits, _empty, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _minterLimits, _empty, _minters);
 
     vm.expectRevert(IXERC20Factory.IXERC20Factory_InvalidLength.selector);
-    _xerc20Factory.deployXERC20('Test', 'TST', 18, _empty, _burnerLimits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _empty, _burnerLimits, _minters);
   }
 
   function testDeployEmitsEvent() public {
@@ -180,20 +152,21 @@ contract UnitDeploy is Base {
     vm.expectEmit(true, true, true, true);
     emit XERC20Deployed(_token);
     vm.prank(_owner);
-    _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _owner, _limits, _limits, _minters);
   }
 
   function testLockboxEmitsEvent() public {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
-    vm.prank(_owner);
-    address _token = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
-    address payable _lockbox = payable(_xerc20Factory.getDeployed(keccak256(abi.encodePacked(_token, _erc20, _owner))));
 
-    vm.expectEmit(true, true, true, true);
-    emit LockboxDeployed(_lockbox);
+    address _xerc20 = _xerc20Factory.getDeployed(keccak256(abi.encodePacked('Test', 'TST', uint8(18), _owner)));
+
+    address payable _lockbox = payable(_xerc20Factory.getDeployed(keccak256(abi.encodePacked(_xerc20, _erc20, _owner))));
+
     vm.prank(_owner);
     vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
-    _xerc20Factory.deployLockbox(_token, _erc20, false);
+    vm.expectEmit(true, true, true, true);
+    emit LockboxDeployed(_lockbox);
+    _xerc20Factory.deployXERC20WithLockbox('Test', 'TST', _owner, _limits, _limits, _minters, _erc20, false);
   }
 }

--- a/solidity/test/unit/XERC20Factory.t.sol
+++ b/solidity/test/unit/XERC20Factory.t.sol
@@ -9,7 +9,9 @@ import {IXERC20Factory} from '../../interfaces/IXERC20Factory.sol';
 import {CREATE3} from 'isolmate/utils/CREATE3.sol';
 
 contract XERC20FactoryForTest is XERC20Factory {
-  function getDeployed(bytes32 _salt) public view returns (address _precomputedAddress) {
+  function getDeployed(
+    bytes32 _salt
+  ) public view returns (address _precomputedAddress) {
     _precomputedAddress = CREATE3.getDeployed(_salt);
   }
 }
@@ -34,7 +36,7 @@ contract UnitDeploy is Base {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters));
+    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters));
     assertEq(_xerc20.name(), 'Test');
     assertEq(_xerc20.symbol(), 'TST');
     assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
@@ -47,7 +49,7 @@ contract UnitDeploy is Base {
     _limits[0] = 1e18;
     _minters[0] = _user;
 
-    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters));
+    XERC20 _xerc20 = XERC20(_xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters));
     assertEq(_xerc20.name(), 'Test');
     assertEq(_xerc20.symbol(), 'TST');
     assertEq(_xerc20.FACTORY(), address(_xerc20Factory));
@@ -58,11 +60,11 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.prank(_owner);
-    _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
 
     vm.prank(_owner);
     vm.expectRevert('DEPLOYMENT_FAILED');
-    _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
   }
 
   function testComputedAddress() public {
@@ -70,9 +72,9 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.startPrank(address(_owner));
-    bytes32 _salt = keccak256(abi.encodePacked('Test', 'TST', _owner));
+    bytes32 _salt = keccak256(abi.encodePacked('Test', 'TST', uint8(18), _owner));
 
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
     vm.stopPrank();
     address _predictedAddress = _xerc20Factory.getDeployed(_salt);
 
@@ -84,7 +86,8 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.startPrank(_owner);
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
+    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
     address payable _lockbox = payable(_xerc20Factory.deployLockbox(_xerc20, _erc20, false));
     vm.stopPrank();
 
@@ -99,8 +102,9 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.startPrank(_owner);
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
 
+    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
     address payable _lockbox = payable(_xerc20Factory.deployLockbox(_xerc20, _erc20, false));
     vm.stopPrank();
 
@@ -113,7 +117,8 @@ contract UnitDeploy is Base {
     address[] memory _minters = new address[](0);
 
     vm.startPrank(_owner);
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
+    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
     vm.stopPrank();
 
     vm.expectRevert(IXERC20Factory.IXERC20Factory_NotOwner.selector);
@@ -134,8 +139,9 @@ contract UnitDeploy is Base {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    address _xerc20 = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
 
+    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
     _xerc20Factory.deployLockbox(_xerc20, _erc20, false);
 
     vm.expectRevert(IXERC20Factory.IXERC20Factory_LockboxAlreadyDeployed.selector);
@@ -153,33 +159,34 @@ contract UnitDeploy is Base {
 
     vm.prank(_owner);
     vm.expectRevert(IXERC20Factory.IXERC20Factory_InvalidLength.selector);
-    _xerc20Factory.deployXERC20('Test', 'TST', _minterLimits, _empty, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _minterLimits, _empty, _minters);
 
     vm.expectRevert(IXERC20Factory.IXERC20Factory_InvalidLength.selector);
-    _xerc20Factory.deployXERC20('Test', 'TST', _empty, _burnerLimits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _empty, _burnerLimits, _minters);
   }
 
   function testDeployEmitsEvent() public {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
 
-    address _token = _xerc20Factory.getDeployed(keccak256(abi.encodePacked('Test', 'TST', _owner)));
+    address _token = _xerc20Factory.getDeployed(keccak256(abi.encodePacked('Test', 'TST', uint8(18), _owner)));
     vm.expectEmit(true, true, true, true);
     emit XERC20Deployed(_token);
     vm.prank(_owner);
-    _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
   }
 
   function testLockboxEmitsEvent() public {
     uint256[] memory _limits = new uint256[](0);
     address[] memory _minters = new address[](0);
     vm.prank(_owner);
-    address _token = _xerc20Factory.deployXERC20('Test', 'TST', _limits, _limits, _minters);
+    address _token = _xerc20Factory.deployXERC20('Test', 'TST', 18, _limits, _limits, _minters);
     address payable _lockbox = payable(_xerc20Factory.getDeployed(keccak256(abi.encodePacked(_token, _erc20, _owner))));
 
     vm.expectEmit(true, true, true, true);
     emit LockboxDeployed(_lockbox);
     vm.prank(_owner);
+    vm.mockCall(address(_erc20), abi.encodeWithSignature('decimals()'), abi.encode(18));
     _xerc20Factory.deployLockbox(_token, _erc20, false);
   }
 }


### PR DESCRIPTION
- Add custom decimals param on `xERC20` allowing lockboxes for `ERC20` tokens with decimals different to `18`.
- Refactor lockbox deployment: deploys xERC20 and xERC20Lockbox together removing unnecessary checks.
