### PR TITLE
OpenZeppelin v5 compatibility + AFI fork baseline

### DIFF
--- a/solidity/contracts/XERC20.sol
+++ b/solidity/contracts/XERC20.sol
@@ -34,7 +34,7 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _symbol The symbol of the token
    * @param _factory The factory which deployed this contract
    */
-  constructor(string memory _name, string memory _symbol, address _factory) ERC20(_name, _symbol) ERC20Permit(_name) {
+  constructor(string memory _name, string memory _symbol, address _factory) ERC20(_name, _symbol) Ownable(msg.sender) ERC20Permit(_name) {
     _transferOwnership(_factory);
     FACTORY = _factory;
   }


### PR DESCRIPTION
- Add Ownable(msg.sender) to constructor initializer list
- Required for OZ v5 which mandates initialOwner parameter
- Maintains existing behavior via _transferOwnership(_factory)
- Enables AFI Protocol contracts to compile with OZ v5